### PR TITLE
Fix ts-jest warnings in e2e tests

### DIFF
--- a/backend-diabets/test/jest-e2e.json
+++ b/backend-diabets/test/jest-e2e.json
@@ -4,7 +4,7 @@
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
+    "^.+\\.ts$": "ts-jest"
   },
   "moduleNameMapper": {
     "^@app/(.*)$": "<rootDir>/src/$1",


### PR DESCRIPTION
## Summary
- adjust jest e2e transform to only process TypeScript files

## Testing
- `npx -y yarn@1 test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_6844638adbe083208e65004c45afeebb