### PR TITLE
Atualiza READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# capillary-glucose-application
+# Capillary Glucose Application
+
+![Banner Principal](docs/banner-main.png)
+
+Repositório contendo todos os serviços que compõem a aplicação de monitoramento de glicose capilar. Cada módulo é executado de forma independente e utiliza **Yarn** para gerenciamento das dependências.
+
+## Estrutura de Pastas
+
+- **backend-diabets** – API construída com [NestJS](https://nestjs.com/).
+- **front-diabets** – Interface em [React](https://reactjs.org/) utilizando [Vite](https://vitejs.dev/).
+- **front-sangue-doce** – Aplicação web em [Next.js](https://nextjs.org/).
+- **strapi-seligadev** – CMS baseado em [Strapi](https://strapi.io/).
+
+## Como iniciar
+
+Certifique‑se de possuir o [Node.js](https://nodejs.org/) e o [Yarn](https://yarnpkg.com/) instalados. Em seguida instale as dependências e execute cada projeto conforme necessário.
+
+### Backend (NestJS)
+```bash
+cd backend-diabets
+yarn install
+yarn start:dev
+```
+
+### Frontend React + Vite
+```bash
+cd front-diabets
+yarn install
+yarn dev
+```
+
+### Frontend Next.js
+```bash
+cd front-sangue-doce
+yarn install
+yarn dev
+```
+
+### CMS Strapi
+```bash
+cd strapi-seligadev
+yarn install
+yarn develop
+```
+
+## Créditos
+
+Este projeto utiliza e agradece aos criadores das seguintes tecnologias:
+
+- [NestJS](https://nestjs.com/)
+- [React](https://reactjs.org/) e [Vite](https://vitejs.dev/)
+- [Next.js](https://nextjs.org/)
+- [Strapi](https://strapi.io/)
+

--- a/backend-diabets/README.md
+++ b/backend-diabets/README.md
@@ -1,99 +1,31 @@
-<p align="center">
-  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
-</p>
+# Backend Diabets
 
-[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
-[circleci-url]: https://circleci.com/gh/nestjs/nest
+![Banner Backend](../docs/backend-banner.png)
 
-  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
-    <p align="center">
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
-<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
-<a href="https://coveralls.io/github/nestjs/nest?branch=master" target="_blank"><img src="https://coveralls.io/repos/github/nestjs/nest/badge.svg?branch=master#9" alt="Coverage" /></a>
-<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
-<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
-<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
-  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg" alt="Donate us"/></a>
-    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
-  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow" alt="Follow us on Twitter"></a>
-</p>
-  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
-  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
+API construída com [NestJS](https://nestjs.com/) para a aplicação de glicose capilar.
 
-## Description
+## Iniciando
 
-[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
-
-## Project setup
+Instale as dependências e execute em modo de desenvolvimento:
 
 ```bash
-$ yarn install
+cd backend-diabets
+yarn install
+yarn start:dev
 ```
 
-## Compile and run the project
+Para gerar a versão de produção:
 
 ```bash
-# development
-$ yarn run start
-
-# watch mode
-$ yarn run start:dev
-
-# production mode
-$ yarn run start:prod
+yarn build
+yarn start:prod
 ```
 
-## Run tests
+### Testes
 
 ```bash
-# unit tests
-$ yarn run test
-
-# e2e tests
-$ yarn run test:e2e
-
-# test coverage
-$ yarn run test:cov
+yarn test
 ```
 
-## Deployment
+Mais detalhes podem ser encontrados na [documentação do NestJS](https://docs.nestjs.com/).
 
-When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.
-
-If you are looking for a cloud-based platform to deploy your NestJS application, check out [Mau](https://mau.nestjs.com), our official platform for deploying NestJS applications on AWS. Mau makes deployment straightforward and fast, requiring just a few simple steps:
-
-```bash
-$ yarn install -g mau
-$ mau deploy
-```
-
-With Mau, you can deploy your application in just a few clicks, allowing you to focus on building features rather than managing infrastructure.
-
-## Resources
-
-Check out a few resources that may come in handy when working with NestJS:
-
-- Visit the [NestJS Documentation](https://docs.nestjs.com) to learn more about the framework.
-- For questions and support, please visit our [Discord channel](https://discord.gg/G7Qnnhy).
-- To dive deeper and get more hands-on experience, check out our official video [courses](https://courses.nestjs.com/).
-- Deploy your application to AWS with the help of [NestJS Mau](https://mau.nestjs.com) in just a few clicks.
-- Visualize your application graph and interact with the NestJS application in real-time using [NestJS Devtools](https://devtools.nestjs.com).
-- Need help with your project (part-time to full-time)? Check out our official [enterprise support](https://enterprise.nestjs.com).
-- To stay in the loop and get updates, follow us on [X](https://x.com/nestframework) and [LinkedIn](https://linkedin.com/company/nestjs).
-- Looking for a job, or have a job to offer? Check out our official [Jobs board](https://jobs.nestjs.com).
-
-## Support
-
-Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
-
-## Stay in touch
-
-- Author - [Kamil Myśliwiec](https://twitter.com/kammysliwiec)
-- Website - [https://nestjs.com](https://nestjs.com/)
-- Twitter - [@nestframework](https://twitter.com/nestframework)
-
-## License
-
-Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# Banners
+
+Coloque aqui as imagens de banner utilizadas nos READMEs.
+
+- `banner-main.png`
+- `backend-banner.png`
+- `front-diabets-banner.png`
+- `front-sangue-doce-banner.png`
+- `strapi-banner.png`
+
+Substitua estes arquivos conforme desejar.

--- a/front-diabets/README.md
+++ b/front-diabets/README.md
@@ -1,54 +1,25 @@
-# React + TypeScript + Vite
+# Front Diabets
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+![Banner Front Diabets](../docs/front-diabets-banner.png)
 
-Currently, two official plugins are available:
+Interface web construída em [React](https://reactjs.org/) com [Vite](https://vitejs.dev/).
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## Iniciando
 
-## Expanding the ESLint configuration
+Execute os comandos abaixo para instalar as dependências e iniciar o servidor de desenvolvimento:
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config({
-  extends: [
-    // Remove ...tseslint.configs.recommended and replace with this
-    ...tseslint.configs.recommendedTypeChecked,
-    // Alternatively, use this for stricter rules
-    ...tseslint.configs.strictTypeChecked,
-    // Optionally, add this for stylistic rules
-    ...tseslint.configs.stylisticTypeChecked,
-  ],
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
+```bash
+cd front-diabets
+yarn install
+yarn dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Para gerar o build de produção e visualizar o resultado:
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default tseslint.config({
-  plugins: {
-    // Add the react-x and react-dom plugins
-    'react-x': reactX,
-    'react-dom': reactDom,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended typescript rules
-    ...reactX.configs['recommended-typescript'].rules,
-    ...reactDom.configs.recommended.rules,
-  },
-})
+```bash
+yarn build
+yarn preview
 ```
+
+Consulte a documentação do [React](https://reactjs.org/) e do [Vite](https://vitejs.dev/) para saber mais.
+

--- a/front-sangue-doce/README.md
+++ b/front-sangue-doce/README.md
@@ -1,36 +1,25 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Front Sangue Doce
 
-## Getting Started
+![Banner Front Sangue Doce](../docs/front-sangue-doce-banner.png)
 
-First, run the development server:
+Aplicação web em [Next.js](https://nextjs.org/) utilizada como alternativa de interface para o projeto.
+
+## Iniciando
 
 ```bash
-npm run dev
-# or
+cd front-sangue-doce
+yarn install
 yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+O servidor é iniciado na porta **3344** por padrão.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+### Produção
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+yarn build
+yarn start
+```
 
-## Learn More
+Para mais informações consulte a [documentação do Next.js](https://nextjs.org/docs).
 
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.

--- a/strapi-seligadev/README.md
+++ b/strapi-seligadev/README.md
@@ -1,62 +1,23 @@
-# 🚀 Getting started with Strapi
+# Strapi Seligadev
 
-Strapi comes with a full featured [Command Line Interface](https://docs.strapi.io/dev-docs/cli) (CLI) which lets you scaffold and manage your project in seconds.
+![Banner Strapi](../docs/strapi-banner.png)
 
-### `develop`
+CMS baseado em [Strapi](https://strapi.io/) utilizado para gerenciar conteúdos da aplicação.
 
-Start your Strapi application with autoReload enabled. [Learn more](https://docs.strapi.io/dev-docs/cli#strapi-develop)
+## Iniciando
 
-```
-npm run develop
-# or
+```bash
+cd strapi-seligadev
+yarn install
 yarn develop
 ```
 
-### `start`
+### Produção
 
-Start your Strapi application with autoReload disabled. [Learn more](https://docs.strapi.io/dev-docs/cli#strapi-start)
-
-```
-npm run start
-# or
+```bash
+yarn build
 yarn start
 ```
 
-### `build`
+Consulte a [documentação do Strapi](https://docs.strapi.io/) para configurações avançadas.
 
-Build your admin panel. [Learn more](https://docs.strapi.io/dev-docs/cli#strapi-build)
-
-```
-npm run build
-# or
-yarn build
-```
-
-## ⚙️ Deployment
-
-Strapi gives you many possible deployment options for your project including [Strapi Cloud](https://cloud.strapi.io). Browse the [deployment section of the documentation](https://docs.strapi.io/dev-docs/deployment) to find the best solution for your use case.
-
-```
-yarn strapi deploy
-```
-
-## 📚 Learn more
-
-- [Resource center](https://strapi.io/resource-center) - Strapi resource center.
-- [Strapi documentation](https://docs.strapi.io) - Official Strapi documentation.
-- [Strapi tutorials](https://strapi.io/tutorials) - List of tutorials made by the core team and the community.
-- [Strapi blog](https://strapi.io/blog) - Official Strapi blog containing articles made by the Strapi team and the community.
-- [Changelog](https://strapi.io/changelog) - Find out about the Strapi product updates, new features and general improvements.
-
-Feel free to check out the [Strapi GitHub repository](https://github.com/strapi/strapi). Your feedback and contributions are welcome!
-
-## ✨ Community
-
-- [Discord](https://discord.strapi.io) - Come chat with the Strapi community including the core team.
-- [Forum](https://forum.strapi.io/) - Place to discuss, ask questions and find answers, show your Strapi project and get feedback or just talk with other Community members.
-- [Awesome Strapi](https://github.com/strapi/awesome-strapi) - A curated list of awesome things related to Strapi.
-
----
-
-<sub>🤫 Psst! [Strapi is hiring](https://strapi.io/careers).</sub>
-# strapi-sweet-blood


### PR DESCRIPTION
## Summary
- add docs folder with banner placeholders
- rewrite project README with instructions for each module
- add clearer READMEs for backend-diabets, front-diabets, front-sangue-doce and strapi-seligadev

## Testing
- `yarn --version`

------
https://chatgpt.com/codex/tasks/task_e_6846de0c17cc832095a8656ab48a210c