### PR TITLE
Add capillary glucose creation form

### DIFF
--- a/front-sangue-doce/src/components/capillary-glucose-form-sheet.tsx
+++ b/front-sangue-doce/src/components/capillary-glucose-form-sheet.tsx
@@ -9,9 +9,12 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
+import { createCapillary } from "@/fetch/glucose";
+import type { CapillaryCreateBody } from "@/types/capillary-request";
 
 
 type CapillaryGlucoseFormProps = React.ComponentProps<"div"> & {
@@ -29,13 +32,24 @@ export function CapillaryGlucoseFormSheet({
   onClose,
   ...props
 }: CapillaryGlucoseFormProps) {
-  const { register, handleSubmit, watch } = useForm<glucoseType>({
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<glucoseType>({
     resolver: zodResolver(GlucoseSchema),
   });
 
-  const onSubmit: SubmitHandler<glucoseType> = (data) => {
-    console.log(data);
-    if (onClose) onClose();
+  const onSubmit: SubmitHandler<glucoseType> = async (data) => {
+    const payload: CapillaryCreateBody = { value: data.value, userId: 1 };
+    try {
+      await createCapillary(payload);
+      toast("Medição criada com sucesso!");
+      if (onClose) onClose();
+    } catch (err) {
+      toast("Erro ao criar medição");
+    }
   };
 
   console.log(watch("value"));
@@ -59,6 +73,9 @@ export function CapillaryGlucoseFormSheet({
                   required
                   {...register("value")}
                 />
+                {errors.value && (
+                  <span className="text-sm text-red-500">{errors.value.message}</span>
+                )}
               </div>
               <div className="flex flex-col gap-3">
                 <Button type="submit" className="w-full cursor-pointer">

--- a/front-sangue-doce/src/fetch/glucose.ts
+++ b/front-sangue-doce/src/fetch/glucose.ts
@@ -15,3 +15,19 @@ export const fetchCapillary = async ({
 
   return response.json();
 };
+
+export const createCapillary = async (body: import("@/types/capillary-request").CapillaryCreateBody) => {
+  const response = await fetch("URL", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Error: Status -> ${response.status} Message -> ${response.statusText}`);
+  }
+
+  return response.json();
+};

--- a/front-sangue-doce/src/types/capillary-request.ts
+++ b/front-sangue-doce/src/types/capillary-request.ts
@@ -1,0 +1,4 @@
+export interface CapillaryCreateBody {
+  value: number;
+  userId: number;
+}


### PR DESCRIPTION
## Summary
- add type for capillary glucose request
- add API fetch helper for creating a capillary glucose entry
- integrate new fetch in `CapillaryGlucoseFormSheet` with validation and toasts

## Testing
- `yarn lint` *(fails: couldn't find node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_68485ed3f17883209a057abcffdb6571